### PR TITLE
travis: cache node_modules so faster build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - "8"
 sudo: false
+cache:
+ directories:
+    - node_modules
 script:
   - npm run lint
   - npm run coverage-all


### PR DESCRIPTION
Right now the time it takes to run a test is not large but in future if the npm packages increases the build will take longer doing so will make build quicker.
