### PR TITLE
add -a flag to apply PR patch & in some cases metadata

### DIFF
--- a/lib/metadata_gen.js
+++ b/lib/metadata_gen.js
@@ -32,9 +32,7 @@ class MetadataGenerator {
       prUrl, reviewedBy, fixes, refs
     };
 
-    const [SCISSOR_LEFT, SCISSOR_RIGHT] = MetadataGenerator.SCISSORS;
     let meta = [
-      SCISSOR_LEFT,
       `PR-URL: ${output.prUrl}`
     ];
     meta = meta.concat(output.fixes.map((fix) => `Fixes: ${fix}`));
@@ -42,7 +40,6 @@ class MetadataGenerator {
     meta = meta.concat(output.reviewedBy.map((r) => {
       return `Reviewed-By: ${r.reviewer.getContact()}`;
     }));
-    meta.push(SCISSOR_RIGHT);
 
     return meta.join('\n');
   }

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -21,6 +21,8 @@ const CIParser = require('./ci');
 const CI_TYPES = CIParser.TYPES;
 const { FULL } = CIParser.constants;
 
+const identity = (i) => i;
+
 class PRChecker {
   constructor(logger, pr, reviewers, comments, reviews, commits, collaborators) {
     this.logger = logger;
@@ -35,16 +37,20 @@ class PRChecker {
   }
 
   checkAll() {
-    this.checkReviews();
-    this.checkPRWait(new Date());
-    this.checkCI();
+    const status = [
+      this.checkReviews(),
+      this.checkPRWait(new Date()),
+      this.checkCI()
+    ];
 
     if (this.authorIsNew()) {
-      this.checkAuthor();
+      status.push(this.checkAuthor());
     }
     // TODO: maybe invalidate review after new commits?
     // TODO: check for pre-backport, Github API v4
     // does not support reading files changed
+
+    return status.every(identity);
   }
 
   getTSCHint(people) {
@@ -64,9 +70,12 @@ class PRChecker {
       pr, logger, reviewers: { rejected, approved }
     } = this;
 
+    let status = true;
+
     if (rejected.length === 0) {
       logger.info(`Rejections: 0`);
     } else {
+      status = false;
       let hint = this.getTSCHint(rejected);
       logger.warn(`Rejections: ${rejected.length}${hint}`);
       for (const { reviewer, review } of rejected) {
@@ -74,6 +83,7 @@ class PRChecker {
       }
     }
     if (approved.length === 0) {
+      status = false;
       logger.warn(`Approvals: 0`);
     } else {
       let hint = this.getTSCHint(approved);
@@ -89,10 +99,13 @@ class PRChecker {
       if (labels.includes('semver-major')) {
         const tscApproval = approved.filter((p) => p.reviewer.isTSC()).length;
         if (tscApproval < 2) {
+          status = false;
           logger.warn('semver-major requires at least two TSC approvals');
         }
       }
     }
+
+    return status;
   }
 
   /**
@@ -127,7 +140,10 @@ class PRChecker {
       const type = wait.isWeekend ? 'weekend' : 'weekday';
       logger.info(`This PR was created on ${dateStr} (${type} in UTC)`);
       logger.warn(`${wait.timeLeft} hours left to land`);
+      return false;
     }
+
+    return true;
   }
 
   // TODO: we might want to check CI status when it's less flaky...
@@ -140,16 +156,21 @@ class PRChecker {
     };
     const thread = comments.concat([prNode]).concat(reviews);
     const ciMap = new CIParser(thread).parse();
+    let status = true;
     if (!ciMap.size) {
       logger.warn('No CI runs detected');
+      return false;
     } else if (!ciMap.get(FULL)) {
       logger.warn('No full CI runs detected');
+      status = false;
     }
 
     for (const [type, ci] of ciMap) {
       const name = CI_TYPES.get(type).name;
       logger.info(`Last ${name} CI on ${ci.date}: ${ci.link}`);
     }
+
+    return status;
   }
 
   authorIsNew() {
@@ -162,7 +183,7 @@ class PRChecker {
 
     const oddCommits = this.filterOddCommits(commits);
     if (!oddCommits.length) {
-      return;
+      return true;
     }
 
     const prAuthor = pr.author.login;
@@ -173,6 +194,7 @@ class PRChecker {
       logger.warn(`Author ${author.email} of commit ${hash} ` +
                   `does not match committer or PR author`);
     }
+    return false;
   }
 
   filterOddCommits(commits) {


### PR DESCRIPTION
*So this is basically just a proof of concept before I clean it up and expand on this work. Wanted to check if there's any interest in this before I spend more than 30 minutes...*

This PR adds `-a` flag that, if there are no warnings, applies a PR patch onto the current branch and if the PR only has a single commit (which has no previous metadata), also applies the generated metadata to it.

I personally already have a bunch of bash scripts that do this for me but I would rather just use one tool for everything, if I can. This would also make landing doc changes and similar much faster.