### PR TITLE
Fix metadata generation test on Windows

### DIFF
--- a/test/unit/metadata_gen.test.js
+++ b/test/unit/metadata_gen.test.js
@@ -6,6 +6,7 @@ const {
   allGreenReviewers
 } = require('../fixtures/data');
 
+const { EOL } = require('os');
 const assert = require('assert');
 const data = {
   repo: 'node',
@@ -23,6 +24,6 @@ Reviewed-By: Bar User <bar@example.com>`;
 describe('MetadataGenerator', () => {
   it('should generate metadata properly', () => {
     const results = new MetadataGenerator(data).getMetadata();
-    assert.strictEqual(expected, results);
+    assert.strictEqual(expected.replace(/\n/g, EOL), results);
   });
 });


### PR DESCRIPTION
On Windows, the strings mismatched due to different EOLs. (Template string literals always use LF while the metadata generator emits CRLF.)