### PR TITLE
Properly use EOL on Windows when logging

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,6 +24,7 @@ const LEVELS = new Map(Object.keys(pino.levels.values)
   .map((key) => [pino.levels.values[key], key.toUpperCase()]));
 
 const prettyOptions = {
+  crlf: EOL === '\r\n',
   forceColor: true,
   formatter(obj) {
     const level = LEVELS.get(obj.level);
@@ -52,6 +53,7 @@ module.exports = function loggerFactory(stream) {
   const pretty = pino.pretty(prettyOptions);
   pretty.pipe(stream);
   const logger = pino({
+    crlf: EOL === '\r\n',
     name: 'node-core-utils',
     safe: true,
     level: 'trace'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "chalk": "^2.2.0",
     "jsdom": "^11.3.0",
-    "pino": "^4.8.0",
+    "pino": "^4.9.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "yargs": "^10.0.3"

--- a/test/unit/logger.test.js
+++ b/test/unit/logger.test.js
@@ -22,25 +22,25 @@ describe('Logger', () => {
     it('should have blue color when the level is INFO', () => {
       logger.info('test');
       assert.strictEqual(stream.toString(),
-        `${chalk.blue('[INFO]')} test\n`);
+        `${chalk.blue('[INFO]')} test${EOL}`);
     });
 
     it('should have red color when the level is FATAL', () => {
       logger.fatal('test');
       assert.strictEqual(stream.toString(),
-        `${chalk.red('[FATAL]')} test\n`);
+        `${chalk.red('[FATAL]')} test${EOL}`);
     });
 
     it('should have yellow color when the level is WARN', () => {
       logger.warn('test');
       assert.strictEqual(stream.toString(),
-        `${chalk.yellow('[WARN]')} test\n`);
+        `${chalk.yellow('[WARN]')} test${EOL}`);
     });
 
     it('should have green color when the level is DEBUG', () => {
       logger.debug('test');
       assert.strictEqual(stream.toString(),
-        `${chalk.green('[DEBUG]')} test\n`);
+        `${chalk.green('[DEBUG]')} test${EOL}`);
     });
   });
 
@@ -70,14 +70,14 @@ describe('Logger', () => {
           `${chalk.red('[ERROR]')} test_error Error with logger.error${EOL}` +
           `${chalk.red('[STACK]')} stack${EOL}${chalk.red('[DATA]')} {${EOL}` +
           `  "reason": "Testing logger.error"${EOL}` +
-        `}${EOL}\n`);
+        `}${EOL}${EOL}`);
       });
 
       it('should print nothing when there is no object to be serialized', () => {
         logger.error('test');
         assert.strictEqual(stream.toString(),
           `${chalk.red('[ERROR]')} test${EOL}` +
-          `${chalk.red('[STACK]')} ${EOL}${chalk.red('[DATA]')} ${EOL}\n`);
+          `${chalk.red('[STACK]')} ${EOL}${chalk.red('[DATA]')} ${EOL}${EOL}`);
       });
     });
 
@@ -94,14 +94,14 @@ describe('Logger', () => {
         logger.info({ raw: 'Some interesting information' }, 'test');
         assert.strictEqual(stream.toString(),
           `${chalk.blue('[INFO]')} test${EOL}` +
-          `Some interesting information\n`);
+          `Some interesting information${EOL}`);
       });
 
       it('should not print message when msg is defined', () => {
         logger.info({ raw: 'Some interesting information' });
         assert.strictEqual(stream.toString(),
           `${chalk.blue('[INFO]')} ${EOL}` +
-          `Some interesting information\n`);
+          `Some interesting information${EOL}`);
       });
     });
   });


### PR DESCRIPTION
This patch ensures proper EOL handling on Windows, but needs https://github.com/pinojs/pino/pull/327 to be merged and released to work.

Refs: https://github.com/joyeecheung/node-core-utils/pull/47