### PR TITLE
add an intro section with useful info

### DIFF
--- a/bin/metadata.js
+++ b/bin/metadata.js
@@ -23,6 +23,8 @@ async function main(prid, owner, repo, logger) {
   const data = new PRData(prid, owner, repo, logger, request);
   await data.getAll();
 
+  data.logIntro();
+
   const metadata = new MetadataGenerator(data).getMetadata();
   const [SCISSOR_LEFT, SCISSOR_RIGHT] = MetadataGenerator.SCISSORS;
   logger.info({

--- a/lib/pr_data.js
+++ b/lib/pr_data.js
@@ -95,6 +95,28 @@ class PRData {
       'repository', 'pullRequest', 'commits'
     ]);
   }
+
+  logIntro() {
+    const {
+      commits,
+      logger,
+      owner,
+      prid,
+      pr: {
+        author: { login: author },
+        baseRefName,
+        headRefName,
+        labels,
+        title
+      }
+    } = this;
+
+    logger.info(`${title} #${prid}`);
+    logger.info(`${author} wants to merge ${commits.length} ` +
+                `commit${commits.length === 1 ? '' : 's'} into ` +
+                `${owner}:${baseRefName} from ${author}:${headRefName}`);
+    logger.info(`Labels: ${labels.nodes.map(label => label.name).join(' ')}`);
+  }
 };
 
 module.exports = PRData;

--- a/queries/PR.gql
+++ b/queries/PR.gql
@@ -13,7 +13,10 @@ query PR($prid: Int!, $owner: String!, $repo: String!) {
         nodes {
           name
         }
-      }
+      },
+      title,
+      baseRefName,
+      headRefName
     }
   }
 }

--- a/test/fixtures/first_timer_pr.json
+++ b/test/fixtures/first_timer_pr.json
@@ -14,5 +14,8 @@
         "name": "test"
       }
     ]
-  }
+  },
+  "title": "test: awesome changes",
+  "baseRefName": "master",
+  "headRefName": "awesome-changes"
 }

--- a/test/fixtures/semver_major_pr.json
+++ b/test/fixtures/semver_major_pr.json
@@ -14,5 +14,8 @@
         "name": "semver-major"
       }
     ]
-  }
+  },
+  "title": "lib: awesome changes",
+  "baseRefName": "master",
+  "headRefName": "awesome-changes"
 }

--- a/test/fixtures/test_logger.js
+++ b/test/fixtures/test_logger.js
@@ -19,6 +19,13 @@ class TestLogger {
     return true;
   }
 
+  clear() {
+    this.logs.warn = [];
+    this.logs.info = [];
+    this.logs.trace = [];
+    this.logs.error = [];
+  }
+
   warn(...args) {
     this.logs.warn.push(args);
   }

--- a/test/unit/pr_data.test.js
+++ b/test/unit/pr_data.test.js
@@ -12,7 +12,6 @@ const {
   readme
 } = require('../fixtures/data');
 const TestLogger = require('../fixtures/test_logger');
-const logger = new TestLogger();
 const PRData = require('../../lib/pr_data');
 
 function toRaw(obj) {
@@ -51,6 +50,7 @@ describe('PRData', function() {
   request.gql.returns(new Error('unknown query'));
 
   it('getAll', async() => {
+    const logger = new TestLogger();
     const data = new PRData(16348, 'nodejs', 'node', logger, request);
     await data.getAll();
     assert.deepStrictEqual(data.collaborators, collaborators);
@@ -59,5 +59,26 @@ describe('PRData', function() {
     assert.deepStrictEqual(data.comments, commentsWithLGTM);
     assert.deepStrictEqual(data.commits, simpleCommits);
     assert.deepStrictEqual(data.reviewers, allGreenReviewers);
+  });
+
+  it('logIntro', async() => {
+    const logger = new TestLogger();
+    const data = new PRData(16348, 'nodejs', 'node', logger, request);
+    await data.getAll();
+    logger.clear();
+
+    const expectedLogs = {
+      warn: [],
+      info: [
+        ['test: awesome changes #16348'],
+        ['pr_author wants to merge 1 commit into nodejs:master from pr_author:awesome-changes'],
+        ['Labels: test']
+      ],
+      error: [],
+      trace: []
+    };
+
+    data.logIntro();
+    assert.deepStrictEqual(logger.logs, expectedLogs);
   });
 });


### PR DESCRIPTION
So this adds three intro lines of logs that are basically the github PR header (title + pr num, commit author, commit count, branch info + labels). I would like to have this info available and I believe there was a request for it in the issues too.

It's implemented on the PRData class which made the most sense to me as it just logs information from that class. Also, we might want to use this on other targets (such as land-pr).

Tests are included.