### PR TITLE
expand checker methods to return check status

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -42,16 +42,20 @@ class PRChecker {
   }
 
   checkAll() {
-    this.checkReviews();
-    this.checkPRWait(new Date());
-    this.checkCI();
+    const status = [
+      this.checkReviews(),
+      this.checkPRWait(new Date()),
+      this.checkCI()
+    ];
 
     if (this.authorIsNew()) {
-      this.checkAuthor();
+      status.push(this.checkAuthor());
     }
     // TODO: maybe invalidate review after new commits?
     // TODO: check for pre-backport, Github API v4
     // does not support reading files changed
+
+    return status.every((i) => i);
   }
 
   getTSCHint(people) {
@@ -70,10 +74,12 @@ class PRChecker {
     const {
       pr, logger, reviewers: { rejected, approved }
     } = this;
+    let status = true;
 
     if (rejected.length === 0) {
       logger.info(`Rejections: 0`);
     } else {
+      status = false;
       let hint = this.getTSCHint(rejected);
       logger.warn(`Rejections: ${rejected.length}${hint}`);
       for (const { reviewer, review } of rejected) {
@@ -81,6 +87,7 @@ class PRChecker {
       }
     }
     if (approved.length === 0) {
+      status = false;
       logger.warn(`Approvals: 0`);
     } else {
       let hint = this.getTSCHint(approved);
@@ -96,10 +103,13 @@ class PRChecker {
       if (labels.includes('semver-major')) {
         const tscApproval = approved.filter((p) => p.reviewer.isTSC()).length;
         if (tscApproval < 2) {
+          status = false;
           logger.warn('semver-major requires at least two TSC approvals');
         }
       }
     }
+
+    return status;
   }
 
   /**
@@ -134,7 +144,10 @@ class PRChecker {
       const type = wait.isWeekend ? 'weekend' : 'weekday';
       logger.info(`This PR was created on ${dateStr} (${type} in UTC)`);
       logger.warn(`${wait.timeLeft} hours left to land`);
+      return false;
     }
+
+    return true;
   }
 
   // TODO: we might want to check CI status when it's less flaky...
@@ -147,9 +160,12 @@ class PRChecker {
     };
     const thread = comments.concat([prNode]).concat(reviews);
     const ciMap = new CIParser(thread).parse();
+    let status = true;
     if (!ciMap.size) {
       logger.warn('No CI runs detected');
+      return false;
     } else if (!ciMap.get(FULL)) {
+      status = false;
       logger.warn('No full CI runs detected');
     }
 
@@ -157,6 +173,8 @@ class PRChecker {
       const name = CI_TYPES.get(type).name;
       logger.info(`Last ${name} CI on ${ci.date}: ${ci.link}`);
     }
+
+    return status;
   }
 
   authorIsNew() {
@@ -169,7 +187,7 @@ class PRChecker {
 
     const oddCommits = this.filterOddCommits(commits);
     if (!oddCommits.length) {
-      return;
+      return true;
     }
 
     const prAuthor = pr.author.login;
@@ -180,6 +198,7 @@ class PRChecker {
       logger.warn(`Author ${author.email} of commit ${hash} ` +
                   `does not match committer or PR author`);
     }
+    return false;
   }
 
   filterOddCommits(commits) {

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -56,7 +56,8 @@ describe('PRChecker', () => {
     });
 
     it('should run necessary checks', () => {
-      checker.checkAll();
+      const status = checker.checkAll();
+      assert.strictEqual(status, false);
       assert.strictEqual(checkReviewsStub.calledOnce, true);
       assert.strictEqual(checkPRWaitStub.calledOnce, true);
       assert.strictEqual(checkCIStub.calledOnce, true);
@@ -91,7 +92,8 @@ describe('PRChecker', () => {
         collaborators
       });
 
-      checker.checkReviews();
+      const status = checker.checkReviews();
+      assert(!status);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
 
@@ -119,7 +121,8 @@ describe('PRChecker', () => {
         collaborators
       });
 
-      checker.checkReviews();
+      const status = checker.checkReviews();
+      assert(!status);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
   });
@@ -149,7 +152,8 @@ describe('PRChecker', () => {
         collaborators
       });
 
-      checker.checkPRWait(now);
+      const status = checker.checkPRWait(now);
+      assert(!status);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
 
@@ -177,7 +181,8 @@ describe('PRChecker', () => {
         collaborators
       });
 
-      checker.checkPRWait(now);
+      const status = checker.checkPRWait(now);
+      assert(!status);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
   });
@@ -204,7 +209,8 @@ describe('PRChecker', () => {
         collaborators
       });
 
-      checker.checkCI();
+      const status = checker.checkCI();
+      assert(!status);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
 
@@ -256,7 +262,8 @@ describe('PRChecker', () => {
         collaborators
       });
 
-      checker.checkCI();
+      const status = checker.checkCI();
+      assert(status);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
   });
@@ -288,7 +295,8 @@ describe('PRChecker', () => {
       });
 
       assert(checker.authorIsNew());
-      checker.checkAuthor();
+      const status = checker.checkAuthor();
+      assert(!status);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
   });


### PR DESCRIPTION
What it says in the PR title, really. This will be useful down the line when we're implementing different targets such as `land-pr` that need to know the status.