### PR TITLE
mocha, appveyor: add flag --exit so appveryor build does not get stuck

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,5 +18,8 @@ test_script:
   - npm run lint
   - npm run coverage-all
 
+cache: 
+  - node_modules
+
 # Don't actually build.
 build: off

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "test": "npm run test-unit && npm run lint",
-    "test-unit": "mocha --require intelli-espower-loader test/unit/*.test.js",
-    "test-all": "mocha --require intelli-espower-loader test/**/*.test.js",
+    "test-unit": "mocha --require intelli-espower-loader test/unit/*.test.js --exit",
+    "test-all": "mocha --require intelli-espower-loader test/**/*.test.js --exit",
     "coverage": "nyc npm test",
     "coverage-all": "nyc npm run test-all",
     "lint": "eslint .",


### PR DESCRIPTION
cache node_modules
this still does not fix test failures of auth but rather exits the
test so joyeecheung does not have to cancel the build manually