### PR TITLE
use ghauth for easier first-time auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,18 @@ CLI tools for Node.js Core collaborators
 
 ## Usage
 
-First, [follow these instructions](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
-to create a personal access token.
+```
+npm install -g node-core-utils
+```
+
+After running any of the tools for the first-time, you will be asked to provide a
+GitHub username and password in order to create a personal access token.
+
+If you prefer not to provide your login credentials, [follow these instructions](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
+to create the token.
 
 Note: We need to read the email of the PR author in order to check if it matches
-the email of the commit author. This requires checking the box `user:email` when 
+the email of the commit author. This requires checking the box `user:email` when
 you create the personal access token (you can edit the permission later as well).
 
 Then create a file named `.ncurc` under your `$HOME` directory (`~/.ncurc`);
@@ -24,9 +31,7 @@ Then create a file named `.ncurc` under your `$HOME` directory (`~/.ncurc`);
 }
 ```
 
-If you install via npm, that's it.
-
-If you are using it from source, install and link:
+If you would prefer to build from the source, install and link:
 
 ```
 git clone git@github.com:joyeecheung/node-core-utils.git

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -23,8 +23,10 @@ async function auth(getCredentials = ghauth) {
   try {
     ({ username, token } = JSON.parse(await readFile(authFile, 'utf8')));
   } catch (e) {
-    process.stdout.write('Reading configuration for node-core-utils failed:\n' +
-                         e.message + '\n');
+    process.stdout.write('If this is your first time running this command, ' +
+                         'follow the instructions to create an access token. ' +
+                         'If you prefer to create it yourself on Github, ' +
+                         'see https://github.com/joyeecheung/node-core-utils/blob/master/README.md.\n');
   }
 
   // If that worked, yay
@@ -43,8 +45,8 @@ async function auth(getCredentials = ghauth) {
       note: 'node-core-utils CLI tools'
     });
   } catch (e) {
-    process.stdout.write(`Could not get token: ${e.message}\n`);
-    process.exit();
+    process.stderr.write(`Could not get token: ${e.message}\n`);
+    process.exit(1);
   }
 
   const json = JSON.stringify({

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -71,8 +71,8 @@ function lazy(fn) {
   };
 }
 
-// This is dirty, dirty hack to get around a bug in hyperquest & ghauth
-// which are currently not truly maintained
+// This is an ugly hack to get around a bug in hyperquest & ghauth
+// which are not currently maintained
 const originalSetTimeout = ClientRequest.prototype.setTimeout;
 ClientRequest.prototype.setTimeout = function(msecs, ...args) {
   msecs = Math.min(msecs, Math.pow(2, 31) - 1);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,10 +2,11 @@
 
 const assert = require('assert');
 const fs = require('fs');
+const { ClientRequest } = require('http');
 const os = require('os');
 const path = require('path');
 const util = require('util');
-const readline = require('readline');
+const ghauth = util.promisify(require('ghauth'));
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 const authFile = path.join(os.homedir(), '.ncurc');
@@ -16,7 +17,7 @@ function check(username, token) {
   assert(typeof token === 'string' && /^[0-9a-f]*/.test(token));
 }
 
-async function auth() {
+async function auth(getCredentials = ghauth) {
   let username, token;
   // Try reading from ~/.ncurc
   try {
@@ -32,46 +33,46 @@ async function auth() {
     return Buffer.from(`${username}:${token}`).toString('base64');
   }
 
-  // Ask the user for input and write to ~/.ncurc, then try again
-  process.stdout.write('Please enter your Github user information:\n' +
-      '[Github tokens can be created as described in ' +
-      'https://help.github.com/articles/' +
-      'creating-a-personal-access-token-for-the-command-line/]\n');
-  username = await prompt('Github user name');
-  token = await prompt('Github token');
-  check(username, token);
-  const json = JSON.stringify({ username, token }, null, '  ');
+  // Ask the user for input, create a token via github v3 API
+  // then write to ~/.ncurc and try auth() again
+  let credentials;
+  try {
+    credentials = await getCredentials({
+      noSave: true,
+      scopes: ['user:email'],
+      note: 'node-core-utils CLI tools'
+    });
+  } catch (e) {
+    process.stdout.write(`Could not get token: ${e.message}\n`);
+    process.exit();
+  }
+
+  const json = JSON.stringify({
+    username: credentials.user,
+    token: credentials.token
+  }, null, '  ');
   await writeFile(authFile, json, { mode:
     0o600 /* owner read/write */
   });
-  return auth();
-}
 
-async function prompt(question) {
-  return new Promise((resolve, reject) => {
-    process.stdout.write(`${question}: `);
-
-    const rl = readline.createInterface({
-      input: process.stdin
-    });
-    rl.on('line', (line) => {
-      rl.close();
-      process.stdin.removeListener('error', reject);
-      process.stdin.removeListener('end', reject);
-      resolve(line.trim());
-    });
-    process.stdin.on('error', reject);
-    process.stdin.on('end', reject);
-  });
+  return auth(getCredentials);
 }
 
 function lazy(fn) {
   let cachedValue;
-  return function() {
+  return function(...args) {
     if (cachedValue !== undefined) {
       return cachedValue;
     }
-    cachedValue = fn();
+    cachedValue = fn(...args);
     return cachedValue;
   };
 }
+
+// This is dirty, dirty hack to get around a bug in hyperquest & ghauth
+// which are currently not truly maintained
+const originalSetTimeout = ClientRequest.prototype.setTimeout;
+ClientRequest.prototype.setTimeout = function(msecs, ...args) {
+  msecs = Math.min(msecs, Math.pow(2, 31) - 1);
+  return originalSetTimeout.call(this, msecs, ...args);
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.2.0",
+    "ghauth": "^3.2.1",
     "jsdom": "^11.3.0",
     "pino": "^4.9.0",
     "request": "^2.83.0",

--- a/test/fixtures/run-auth.js
+++ b/test/fixtures/run-auth.js
@@ -2,9 +2,16 @@
 
 const assert = require('assert');
 
+async function mockCredentials() {
+  return {
+    user: 'nyancat',
+    token: '0123456789abcdef'
+  };
+}
+
 (async function() {
   const auth = require('../../lib/auth');
-  const authParams = await auth();
-  assert.strictEqual(await auth(), authParams);
+  const authParams = await auth(mockCredentials);
+  assert.strictEqual(await auth(mockCredentials), authParams);
   console.log(authParams);
 })();

--- a/test/unit/auth.test.js
+++ b/test/unit/auth.test.js
@@ -13,8 +13,10 @@ describe('auth', async function() {
   it('asks for auth data if no ncurc is found', async function() {
     this.timeout(1500);
     await runAuthScript(undefined, [
-      'Reading configuration for node-core-utils failed:',
-      /ENOENT: no such file or directory, open/,
+      'If this is your first time running this command, ' +
+      'follow the instructions to create an access token. ' +
+      'If you prefer to create it yourself on Github, ' +
+      'see https://github.com/joyeecheung/node-core-utils/blob/master/README.md.',
       'bnlhbmNhdDowMTIzNDU2Nzg5YWJjZGVm'
     ]);
   });
@@ -22,8 +24,10 @@ describe('auth', async function() {
   it('asks for auth data if ncurc is invalid json', async function() {
     this.timeout(1500);
     await runAuthScript('this is not json', [
-      'Reading configuration for node-core-utils failed:',
-      /Unexpected token h in JSON at position 1/,
+      'If this is your first time running this command, ' +
+      'follow the instructions to create an access token. ' +
+      'If you prefer to create it yourself on Github, ' +
+      'see https://github.com/joyeecheung/node-core-utils/blob/master/README.md.',
       'bnlhbmNhdDowMTIzNDU2Nzg5YWJjZGVm'
     ]);
   });

--- a/test/unit/auth.test.js
+++ b/test/unit/auth.test.js
@@ -15,10 +15,6 @@ describe('auth', async function() {
     await runAuthScript(undefined, [
       'Reading configuration for node-core-utils failed:',
       /ENOENT: no such file or directory, open/,
-      'Please enter your Github user information:',
-      /Github tokens can be created as described in/,
-      { expected: 'Github user name: ', reply: 'nyancat' },
-      { expected: 'Github token: ', reply: '0123456789abcdef' },
       'bnlhbmNhdDowMTIzNDU2Nzg5YWJjZGVm'
     ]);
   });
@@ -28,10 +24,6 @@ describe('auth', async function() {
     await runAuthScript('this is not json', [
       'Reading configuration for node-core-utils failed:',
       /Unexpected token h in JSON at position 1/,
-      'Please enter your Github user information:',
-      /Github tokens can be created as described in/,
-      { expected: 'Github user name: ', reply: 'nyancat' },
-      { expected: 'Github token: ', reply: '0123456789abcdef' },
       'bnlhbmNhdDowMTIzNDU2Nzg5YWJjZGVm'
     ]);
   });


### PR DESCRIPTION
This enables the use of [rvagg/ghauth](https://github.com/rvagg/ghauth) for first-time users instead of a user supplied token that creates the `.ncurc` file. I think this is a slightly nicer user experience. (If they already have a token, creating a `~/.ncurc` file from the terminal seems easy...)

Didn't have to change a ton, especially with the test case — great job on making that code generic enough that it could be so easily repurposed @addaleax!

Fixes: https://github.com/joyeecheung/node-core-utils/issues/1