### PR TITLE
fix the parsing of fixes

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -10,19 +10,20 @@ const { JSDOM } = require('jsdom');
  * Most of this class is ported from node-review
  */
 class LinkParser {
-  constructor(repo, html) {
+  constructor(owner, repo, html) {
+    this.owner = owner;
     this.repo = repo;
     this.OP = JSDOM.fragment(html);
   }
 
   getFixesUrlsFromArray(arr) {
-    const repo = this.repo;
+    const { owner, repo } = this;
     const result = [];
     for (const item of arr) {
       const m = item.match(FIX_RE);
       if (!m) continue;
       const fix = m[3];
-      const url = fix.replace(/^#/, `${repo}#`).replace('#', '/issues/');
+      const url = fix.replace(/^#/, `${owner}/${repo}#`).replace('#', '/issues/');
       result.push(`https://github.com/${url}`);
     }
     return result;

--- a/lib/metadata_gen.js
+++ b/lib/metadata_gen.js
@@ -10,7 +10,8 @@ class MetadataGenerator {
    * @param {PRData} data
    */
   constructor(data) {
-    const { repo, pr, reviewers } = data;
+    const { owner, repo, pr, reviewers } = data;
+    this.owner = owner;
     this.repo = repo;
     this.pr = pr;
     this.reviewers = reviewers;
@@ -23,10 +24,11 @@ class MetadataGenerator {
     const {
       reviewers: { approved: reviewedBy },
       pr: { url: prUrl, bodyHTML: op },
+      owner,
       repo
     } = this;
 
-    const parser = new LinkParser(repo, op);
+    const parser = new LinkParser(owner, repo, op);
     const fixes = parser.getFixes();
     const refs = parser.getRefs();
 

--- a/test/unit/links.test.js
+++ b/test/unit/links.test.js
@@ -20,7 +20,7 @@ describe('LinkParser', () => {
   it('should parse fixes and refs', () => {
     for (let i = 0; i < htmls.length; ++i) {
       const op = htmls[i];
-      const parser = new LinkParser('nodejs/node', op);
+      const parser = new LinkParser('nodejs', 'node', op);
       const actual = {
         fixes: parser.getFixes(),
         refs: parser.getRefs()

--- a/test/unit/metadata_gen.test.js
+++ b/test/unit/metadata_gen.test.js
@@ -9,13 +9,14 @@ const {
 const { EOL } = require('os');
 const assert = require('assert');
 const data = {
+  owner: 'nodejs',
   repo: 'node',
   pr: fixAndRefPR,
   reviewers: allGreenReviewers
 };
 
 const expected = `PR-URL: https://github.com/nodejs/node/pull/16438
-Fixes: https://github.com/node/issues/16437
+Fixes: https://github.com/nodejs/node/issues/16437
 Refs: https://github.com/nodejs/node/pull/15148
 Reviewed-By: Foo User <foo@example.com>
 Reviewed-By: Baz User <baz@example.com>


### PR DESCRIPTION
This fixes a very serious bug in parsing & creating Fixes URLs. Noticed it while landing: https://github.com/nodejs/node/commit/291ff72f859df3c4c3849021419f37cd542840a6

This should warrant a new release on npm since this makes `get-metadata` very problematic to use.