### PR TITLE
editorconfig: set insert_final_newline to true

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,4 +8,4 @@ indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = false
+insert_final_newline = true


### PR DESCRIPTION
Now, editorconfig automatically inserts a final new line when saving a file.

Related to: https://github.com/joyeecheung/node-core-utils/pull/71/ and https://github.com/joyeecheung/node-core-utils/issues/76