### PR TITLE
less processing of metadata in the bin target

### DIFF
--- a/bin/metadata.js
+++ b/bin/metadata.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-const { EOL } = require('os');
 const Request = require('../lib/request');
 const auth = require('../lib/auth');
 
@@ -28,11 +27,11 @@ async function main(prid, owner, repo, logger) {
   const metadata = new MetadataGenerator(data).getMetadata();
   const [SCISSOR_LEFT, SCISSOR_RIGHT] = MetadataGenerator.SCISSORS;
   logger.info({
-    raw: [SCISSOR_LEFT, metadata, SCISSOR_RIGHT].join(EOL)
+    raw: `${SCISSOR_LEFT}${metadata}${SCISSOR_RIGHT}`
   }, 'Generated metadata:');
 
   if (!process.stdout.isTTY) {
-    process.stdout.write(`${metadata}${EOL}`);
+    process.stdout.write(metadata);
   }
   const checker = new PRChecker(logger, data);
   checker.checkAll();

--- a/lib/metadata_gen.js
+++ b/lib/metadata_gen.js
@@ -32,26 +32,21 @@ class MetadataGenerator {
     const fixes = parser.getFixes();
     const refs = parser.getRefs();
 
-    const output = {
-      prUrl, reviewedBy, fixes, refs
-    };
-
     let meta = [
-      `PR-URL: ${output.prUrl}`
+      `PR-URL: ${prUrl}`,
+      ...fixes.map((fix) => `Fixes: ${fix}`),
+      ...refs.map((ref) => `Refs: ${ref}`),
+      ...reviewedBy.map((r) => `Reviewed-By: ${r.reviewer.getContact()}`),
+      '' // creates final EOL
     ];
-    meta = meta.concat(output.fixes.map((fix) => `Fixes: ${fix}`));
-    meta = meta.concat(output.refs.map((ref) => `Refs: ${ref}`));
-    meta = meta.concat(output.reviewedBy.map((r) => {
-      return `Reviewed-By: ${r.reviewer.getContact()}`;
-    }));
 
     return meta.join(EOL);
   }
 }
 
 MetadataGenerator.SCISSORS = [
-  '-------------------------------- >8 --------------------------------',
-  '-------------------------------- 8< --------------------------------'
+  `-------------------------------- >8 --------------------------------${EOL}`,
+  `-------------------------------- 8< --------------------------------${EOL}`
 ];
 
 module.exports = MetadataGenerator;

--- a/test/unit/metadata_gen.test.js
+++ b/test/unit/metadata_gen.test.js
@@ -20,7 +20,8 @@ Fixes: https://github.com/nodejs/node/issues/16437
 Refs: https://github.com/nodejs/node/pull/15148
 Reviewed-By: Foo User <foo@example.com>
 Reviewed-By: Baz User <baz@example.com>
-Reviewed-By: Bar User <bar@example.com>`;
+Reviewed-By: Bar User <bar@example.com>
+`;
 
 describe('MetadataGenerator', () => {
   it('should generate metadata properly', () => {


### PR DESCRIPTION
Just small changes to do less manipulation of metadata inside the `get-metadata` target so that we don't need to duplicate this code in any other targets that use metadata.

Also simplified the meta array generation to use spread operators — just lets us keep that code a lot shorter and easier to read.