### PR TITLE
improve coverage for auth

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,13 +3,13 @@
 const assert = require('assert');
 const fs = require('fs');
 const { ClientRequest } = require('http');
-const os = require('os');
+const { homedir, EOL } = require('os');
 const path = require('path');
 const util = require('util');
 const ghauth = util.promisify(require('ghauth'));
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
-const authFile = path.join(os.homedir(), '.ncurc');
+const authFile = path.join(homedir(), '.ncurc');
 module.exports = lazy(auth);
 
 function check(username, token) {
@@ -26,7 +26,8 @@ async function auth(getCredentials = ghauth) {
     process.stdout.write('If this is your first time running this command, ' +
                          'follow the instructions to create an access token. ' +
                          'If you prefer to create it yourself on Github, ' +
-                         'see https://github.com/joyeecheung/node-core-utils/blob/master/README.md.\n');
+                         'see https://github.com/joyeecheung/node-core-utils/blob/master/README.md.' +
+                         EOL);
   }
 
   // If that worked, yay
@@ -45,7 +46,7 @@ async function auth(getCredentials = ghauth) {
       note: 'node-core-utils CLI tools'
     });
   } catch (e) {
-    process.stderr.write(`Could not get token: ${e.message}\n`);
+    process.stderr.write(`Could not get token: ${e.message}${EOL}`);
     process.exit(1);
   }
 

--- a/test/fixtures/run-auth-error.js
+++ b/test/fixtures/run-auth-error.js
@@ -1,0 +1,10 @@
+'use strict';
+
+async function mockCredentials() {
+  throw new Error('Bad credentials');
+}
+
+(async function() {
+  const auth = require('../../lib/auth');
+  await auth(mockCredentials);
+})();

--- a/test/fixtures/run-auth.js
+++ b/test/fixtures/run-auth.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { EOL } = require('os');
 
 async function mockCredentials() {
   return {
@@ -13,5 +14,5 @@ async function mockCredentials() {
   const auth = require('../../lib/auth');
   const authParams = await auth(mockCredentials);
   assert.strictEqual(await auth(mockCredentials), authParams);
-  console.log(authParams);
+  process.stdout.write(`${authParams}${EOL}`);
 })();


### PR DESCRIPTION
Add test case to cover the error state of `getCredentials`. Also changed `auth` to use `os.EOL`.

Fixes: #36