### PR TITLE
pr_checker: add warn about conflicts

### DIFF
--- a/lib/mergeable_state.js
+++ b/lib/mergeable_state.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  CONFLICTING: 'CONFLICTING',
+  MERGEABLE: 'MERGEABLE',
+  UNKNOWN: 'UNKNOWN'
+};

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -16,6 +16,9 @@ const {
 const {
   FIRST_TIME_CONTRIBUTOR, FIRST_TIMER
 } = require('./user_status');
+const {
+  CONFLICTING
+} = require('./mergeable_state');
 
 const CIParser = require('./ci');
 const CI_TYPES = CIParser.TYPES;
@@ -50,7 +53,8 @@ class PRChecker {
       this.checkReviews(),
       this.checkCommitsAfterReview(),
       this.checkPRWait(new Date()),
-      this.checkCI()
+      this.checkCI(),
+      this.checkMergeableState()
     ];
 
     if (this.authorIsNew()) {
@@ -264,6 +268,20 @@ class PRChecker {
           logger.warn(`- ${commit.message.split('\n')[0]}`);
         }
       });
+    }
+
+    return status;
+  }
+
+  checkMergeableState() {
+    const {
+      pr, logger
+    } = this;
+
+    let status = true;
+    if (pr.mergeable && pr.mergeable === CONFLICTING) {
+      logger.warn('This PR has conflicts that must be resolved');
+      status = false;
     }
 
     return status;

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -278,13 +278,12 @@ class PRChecker {
       pr, logger
     } = this;
 
-    let status = true;
     if (pr.mergeable && pr.mergeable === CONFLICTING) {
       logger.warn('This PR has conflicts that must be resolved');
-      status = false;
+      return false;
     }
 
-    return status;
+    return true;
   }
 }
 

--- a/queries/PR.gql
+++ b/queries/PR.gql
@@ -16,7 +16,8 @@ query PR($prid: Int!, $owner: String!, $repo: String!) {
       },
       title,
       baseRefName,
-      headRefName
+      headRefName,
+      mergeable
     }
   }
 }

--- a/test/fixtures/conflicting_pr.json
+++ b/test/fixtures/conflicting_pr.json
@@ -1,0 +1,21 @@
+{
+  "createdAt": "2017-10-24T11:13:43Z",
+  "author": {
+    "login": "pr_author",
+    "email": "pr_author@example.com"
+  },
+  "url": "https://github.com/nodejs/node/pull/15256",
+  "bodyHTML": "<p>This PR has conflicts</p>",
+  "bodyText": "This PR has conflicts",
+  "labels": {
+    "nodes": [
+      {
+        "name": "test"
+      }
+    ]
+  },
+  "title": "test: This PR has conflicts",
+  "baseRefName": "master",
+  "headRefName": "pr-conflicts",
+  "mergeable": "CONFLICTING"
+}

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -50,6 +50,7 @@ const collaborators = new Map(
 const firstTimerPR = readJSON('first_timer_pr.json');
 const semverMajorPR = readJSON('semver_major_pr.json');
 const fixAndRefPR = readJSON('pr_with_fixes_and_refs.json');
+const conflictingPR = readJSON('conflicting_pr.json');
 const readme = readFile('./README/README.md');
 const readmeNoTsc = readFile('./README/README_no_TSC.md');
 const readmeNoTscE = readFile('./README/README_no_TSCE.md');
@@ -74,6 +75,7 @@ module.exports = {
   firstTimerPR,
   semverMajorPR,
   fixAndRefPR,
+  conflictingPR,
   readme,
   readmeNoTsc,
   readmeNoTscE,


### PR DESCRIPTION
Question:
- Should we log something when `mergeable === 'UNKNOWN'`?

Please, review it, I don't know if I put all the things in the correct place.

![demo](https://user-images.githubusercontent.com/15221596/32466379-1697b814-c347-11e7-9183-3624818bc5bf.png)

Fixes:  https://github.com/joyeecheung/node-core-utils/issues/68