### PR TITLE
add steps directory to npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-*.json
-!package.json
-test
-.git
-.nyc_output
-coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-core-utils",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "files": [
     "lib/",
     "bin/",
-    "queries/"
+    "queries/",
+    "steps/"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This also removes .npmignore because the "files" array in package.json
has priority over this file.

Fixes: https://github.com/joyeecheung/node-core-utils/issues/90